### PR TITLE
[TASK] Raise supported PHP version to 5.6.x

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -34,7 +34,7 @@ $EM_CONF[$_EXTKEY] = array (
 	'_md5_values_when_last_written' => '',
 	'constraints' => array (
 		'depends' => array (
-			'php' => '5.3.7-5.5.999',
+			'php' => '5.3.7-5.6.999',
 			'typo3' => '6.2.6-7.99.99',
 		),
 		'conflicts' => array (


### PR DESCRIPTION
I had no problems and to add a additional test i run 5.6 PHPCompatibility test.

phpcs --standard=PHPCompatibility --runtime-set testVersion 5.6 --extensions=php /var/www/typo3conf/ext/realurl
-> No errors
