### PR TITLE
[TASK] Remove usage of deprecated GeneralUtility::array_merge()

### DIFF
--- a/Classes/UriGeneratorAndResolver.php
+++ b/Classes/UriGeneratorAndResolver.php
@@ -1111,7 +1111,7 @@ class UriGeneratorAndResolver implements SingletonInterface {
 		$allTitles = array();
 		foreach ($segTitleFieldArray as $fieldName) {
 			if (is_array($titles[$fieldName])) {
-				$allTitles = GeneralUtility::array_merge($allTitles, $titles[$fieldName]);
+				$allTitles = $titles[$fieldName] + $allTitles;
 			}
 		}
 


### PR DESCRIPTION
Replace it with exactly what GeneralUtility::array_merge() does:
$array2 + $array1
