### PR TITLE
[FEATURE] Add configuration for including siteroots in url path

### DIFF
--- a/Classes/Hooks/UrlRewritingHook.php
+++ b/Classes/Hooks/UrlRewritingHook.php
@@ -130,6 +130,7 @@ class UrlRewritingHook implements SingletonInterface
 
     public $enableStrictMode = false;
     public $enableChashDebug = false;
+    public $includeSiterootInUrl = false;
 
     /**
      * If non-empty, corresponding URL query parameter will be ignored in preVars
@@ -179,6 +180,7 @@ class UrlRewritingHook implements SingletonInterface
         $sysconf = (array)unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['realurl']);
         $this->enableStrictMode = (bool)$sysconf['enableStrictMode'];
         $this->enableChashUrlDebug = (bool)$sysconf['enableChashUrlDebug'];
+        $this->includeSiterootInUrl = (bool)$sysconf['includeSiterootInUrl'];
 
         $this->initDevLog($sysconf);
     }

--- a/Classes/UriGeneratorAndResolver.php
+++ b/Classes/UriGeneratorAndResolver.php
@@ -573,7 +573,12 @@ class UriGeneratorAndResolver implements SingletonInterface
     protected function rootLineToPath($rl, $lang)
     {
         $paths = array();
-        array_shift($rl); // Ignore the first path, as this is the root of the website
+
+        // Ignore the first path, if the first site is our configured rootpage and siteroots should not be shown in url path
+        if ($this->pObj->includeSiterootInUrl && $rl[0]['uid'] == $this->conf['rootpage_id']) {
+            array_shift($rl);
+        }
+
         $c = count($rl);
         $stopUsingCache = false;
         $this->pObj->devLog('rootLineToPath starts searching', array('rootline size' => count($rl)));

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -4,6 +4,9 @@ configFile = typo3conf/realurl_conf.php
 # cat=basic/enable; type=boolean; label=Enable automatic configuration:Enable this if you do not want to write configuration manually. It will generate configuration automatically and store it in typo3conf/. Automatically ignored if you wrote configuration yourself. See manual for more information.
 enableAutoConf = 1
 
+# cat=basic/enable; type=boolean; label=Include pages marked as siteroot in URL path (if siteroot is not the configured rootpage)
+includeSiterootInUrl = 0
+
 # cat=basic/enable; type=boolean; label=Enable devLog:Debugging-only! Required any 3rd party devLog extension
 enableDevLog = 0
 


### PR DESCRIPTION
Realurl ignores pathes of pages marked as siteroot. So when you have multiple siteroots in your domain (see attached screen) pathes are not calculated proper. Both "home" sites in "de" and "nl" are available under domain.tld/home/ (or domain.tld/home1/). With this feature you could allow realurl to respect siteroots in pathes so that the calculated url's will be domain.tld/de/home/ or domain.tld/nl/home/

![image](https://cloud.githubusercontent.com/assets/8256874/19962983/a56f8102-a1ba-11e6-91ec-2fb6f71d3141.png)
