### PR TITLE
Allow TYPO3 version 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"license": "GPL-2.0+",
 
 	"require": {
-		"typo3/cms-core": "^6.2.6 || ^7.6 || >=8.0.0 <8.5"
+		"typo3/cms-core": "^6.2.6 || ^7.6 || >=8.0.0 <8.6"
 	},
 	"replace": {
 		"realurl": "self.version"


### PR DESCRIPTION
raise TYPO3 core required version to include 8.5.*