### PR TITLE
[FEATURE] Reimplements backport to set the location of the autoconf file

### DIFF
--- a/Classes/Configuration/ConfigurationGenerator.php
+++ b/Classes/Configuration/ConfigurationGenerator.php
@@ -39,8 +39,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 class ConfigurationGenerator
 {
 
-    const AUTOCONFIGURTION_FILE = 'typo3conf/realurl_autoconf.php';
-
     /**
      * @var \TYPO3\CMS\Core\Database\DatabaseConnection
      */
@@ -58,7 +56,7 @@ class ConfigurationGenerator
      */
     public function generateConfiguration()
     {
-        $fileName = PATH_site . self::AUTOCONFIGURTION_FILE;
+        $fileName = PATH_site . TX_REALURL_AUTOCONF_FILE;
         if (class_exists('TYPO3\\CMS\\Core\\Locking\\LockFactory')) {
             $lockFactory = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Locking\\LockFactory');
             $lockObject = $lockFactory->createLocker(

--- a/Classes/Hooks/DataHandling/DataHandlerHook.php
+++ b/Classes/Hooks/DataHandling/DataHandlerHook.php
@@ -54,7 +54,7 @@ class DataHandlerHook implements SingletonInterface
     protected function clearAutoConfiguration($tableName)
     {
         if ($tableName === 'sys_domain') {
-            @unlink(PATH_site . ConfigurationGenerator::AUTOCONFIGURTION_FILE);
+            @unlink(PATH_site . TX_REALURL_AUTOCONF_FILE);
         }
     }
 

--- a/Classes/Hooks/UrlRewritingHook.php
+++ b/Classes/Hooks/UrlRewritingHook.php
@@ -2197,7 +2197,7 @@ class UrlRewritingHook implements SingletonInterface
         $realUrlConf = (array)@unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['realurl']);
         // Autoconfiguration
         if ($realUrlConf['enableAutoConf']) {
-            $autoConfPath = PATH_site . \Tx\Realurl\Configuration\ConfigurationGenerator::AUTOCONFIGURTION_FILE;
+            $autoConfPath = PATH_site . TX_REALURL_AUTOCONF_FILE;
             $testConf = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl'];
             if (is_array($testConf)) {
                 unset($testConf['getHost']);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,6 +1,10 @@
 <?php
 defined('TYPO3_MODE') or die('Access denied.');
 
+if (!defined('TX_REALURL_AUTOCONF_FILE')) {
+    define('TX_REALURL_AUTOCONF_FILE', 'typo3conf/realurl_autoconf.php');
+}
+
 call_user_func(function ($extensionConfiguration) {
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tstemplate.php']['linkData-PostProc']['tx_realurl'] = 'Tx\\Realurl\\Hooks\\UrlRewritingHook->encodeSpURL';
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['typoLink_PostProc']['tx_realurl'] = 'Tx\\Realurl\\Hooks\\UrlRewritingHook->encodeSpURL_urlPrepend';
@@ -24,7 +28,7 @@ call_user_func(function ($extensionConfiguration) {
         }
     }
 
-    $_realurl_conf_file = PATH_site . \Tx\Realurl\Configuration\ConfigurationGenerator::AUTOCONFIGURTION_FILE;
+    $_realurl_conf_file = PATH_site . TX_REALURL_AUTOCONF_FILE;
     if ($_realurl_conf['enableAutoConf'] && !isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']) && file_exists($_realurl_conf_file)) {
         require_once $_realurl_conf_file;
     }


### PR DESCRIPTION
In realurl 1.x it was possible to set the location of the
autoconfiguration file with a define() statement.
This patch reimplements the possibility to change the location.