### PR TITLE
[BUGFIX] define TYPO3_db_host if not defined

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -31,4 +31,9 @@ call_user_func(function ($extensionConfiguration) {
 
     define('TX_REALURL_SEGTITLEFIELDLIST_DEFAULT', 'tx_realurl_pathsegment,alias,nav_title,title,uid');
     define('TX_REALURL_SEGTITLEFIELDLIST_PLO', 'tx_realurl_pathsegment,nav_title,title,uid');
+    if (!defined('TYPO3_db_host')) {
+        define('TYPO3_db_host', isset($GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host'])
+              ? $GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']['Default']['host']
+              : 'localhost');
+    }
 }, $_EXTCONF);


### PR DESCRIPTION
In Classes/UriGeneratorAndResolver.php:1205 the old constant TYPO3_db_host is used.
This patch define the old constant in case it is not defined. The solution should be work
with all supported versions and don't need additional checks or changes in the code.