### PR TITLE
[BUGFIX] Fix wrong package name of dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 
 	"require": {
 		"typo3/cms-core": "^6.2.6 || ^7.6 || >=8.0.0 <8.8",
-		"symfony/polyfill_mbstring": "^1.7"
+		"symfony/polyfill-mbstring": "^1.7"
 	},
 	"replace": {
 		"realurl": "self.version"


### PR DESCRIPTION
change package name from symfony/polyfill_mbstring to symfony/polyfill-mbstring