### PR TITLE
[BUGFIX] Add current hostname to "additionalParametersForChash" (#47)

### DIFF
--- a/Classes/Hooks/UrlRewritingHook.php
+++ b/Classes/Hooks/UrlRewritingHook.php
@@ -2390,7 +2390,9 @@ class UrlRewritingHook implements SingletonInterface
     {
         $result = false;
 
-        $this->additionalParametersForChash = array();
+        $this->additionalParametersForChash = array(
+            $this->getHost()
+        );
 
         if (isset($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DOMAINS'])) {
             $configuration = $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['realurl']['_DOMAINS'];


### PR DESCRIPTION
The internal chash cache (database table tx_realurl_chashcache) maps
a given combination of query string and query parameters to a single
chash value. It's intended to not recalculate chashe values when
resolving GETvars from SEO URLs but to just look them up.

This can conflict when common non-page records should be displayed on
different detail pages on different root pages that share the same
language and by accident the same page path to the detail page.